### PR TITLE
Fix log date in filename calculated at server run

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ export default function viteDevLogger(
     if (!existsSync(pluginOptions.outputFolder as string)) {
         mkdirSync(pluginOptions.outputFolder as string);
     }
-    const todayDate = new Date().toISOString().split('T')[0];
     return {
         name: 'vite-dev-logger',
         configureServer(server) {
@@ -51,6 +50,7 @@ export default function viteDevLogger(
                 req.on('end', () => {
                     try {
                         const data = JSON.parse(body);
+                        const todayDate = new Date().toISOString().split('T')[0];
                         appendFileSync(
                             `${pluginOptions.outputFolder}/${pluginOptions.outputFileName}-${todayDate}.log`,
                             JSON.stringify(data, null, 0) + '\n'


### PR DESCRIPTION
The log file name includes the current date at server startup (const todayDate = ...). If the server runs past midnight, logs will continue being written to the previous day's file until the server restarts. Ideally, the log file name should be re-evaluated for each request.